### PR TITLE
RPi4: cleaner retroarh build flags

### DIFF
--- a/packages/libretro/retroarch/package.mk
+++ b/packages/libretro/retroarch/package.mk
@@ -94,7 +94,7 @@ elif [ "$OPENGLES" == "allwinner-mali" ] || [ "$OPENGLES" == "odroidxu3-mali" ];
   RETROARCH_GL="--enable-opengles --enable-kms --disable-x11"
 elif [ "$OPENGLES" == "mesa" ]; then
   if [ "$DEVICE" == "RPi4" ]; then
-    RETROARCH_GL="--enable-opengles --enable-opengles3 --enable-opengl_core --enable-kms --disable-x11 --disable-videocore --enable-plain_drm"
+    RETROARCH_GL="--disable-x11 --enable-opengles --enable-opengles3_1 --disable-opengles3_2 --disable-videocore --enable-kms --enable-egl --disable-wayland"
   else
     RETROARCH_GL="--enable-opengles --enable-kms --disable-x11"
   fi


### PR DESCRIPTION
- Leaving "enable-vulkan" out for now -> tbt